### PR TITLE
Issue #3: Add capability to read consumption data form the API

### DIFF
--- a/constant.py
+++ b/constant.py
@@ -1,0 +1,5 @@
+# Update paths to log file and session file.
+# Use full paths if you are executing the script with crontab!
+LOGFILE = '/full/path/to/logfile.log'
+SESSIONFILE = '/full/path/to/session.txt'
+METERING_POINT = 'your-metering-point-number'

--- a/datahub-consumption.py
+++ b/datahub-consumption.py
@@ -11,7 +11,7 @@ logging.basicConfig(
 
 logging.info('Starting to fetch power consumption data from Fingrid Datahub...')
 
-metering_point = constant.ETERING_POINT
+metering_point = constant.METERING_POINT
 period_start = fg.prepare_start_time(1)
 period_end = fg.prepare_end_time(1)
 

--- a/datahub-consumption.py
+++ b/datahub-consumption.py
@@ -1,0 +1,57 @@
+import constant
+import pyfingrid as fg
+import json
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(message)s',
+    filename=constant.LOGFILE,
+    filemode='a')
+
+def get_cookies_from_file():
+    """Reads cookies from session.txt
+    
+    Returns:
+        dict -- Variables of the Datahub cookie.
+    """
+    try:
+        f = open(constant.SESSIONFILE)
+        cookies = json.loads(f.readline())
+        f.close()
+    except:
+        logging.exception("Unable to open session file or invalid file content!")
+        raise
+
+    return cookies
+
+if __name__ == '__main__':
+    logging.info('Starting to fetch power consumption data from Fingrid Datahub...')
+
+    cookies = get_cookies_from_file()
+    session = fg.get_session(cookies)
+
+    metering_point = constant.METERING_POINT
+    period_start = fg.prepare_start_time(1)
+    period_end = fg.prepare_end_time(1)
+
+    try:
+        response = fg.get_consumption_data(metering_point, period_start, period_end, session)
+    except:
+        logging.exception('Unexpected response from Datahub API!')
+        raise
+
+    try:
+        consumption = json.loads(response)
+        items = consumption['TimeSeries'][0]['Observations']
+    except:
+        logging.info('No consumption data available for the selected time range.')
+        raise
+
+    for item in items:
+        timestamp = item['PeriodStartTime']
+        value = float(item['Quantity'])
+        # Save the values where you want, this example simply prints the consumption.
+        print(timestamp + ": " + str(value) + " kWh")
+        
+    logging.info('Consumption successfully fetched from Datahub!')


### PR DESCRIPTION
1. I added a method get_consumption_data() to pyfingrid.py
This makes an API query to https://oma.datahub.fi/_api/GetConsumptionData. I have no idea what the productType argument is in the URL, this is what I had. Do you have the same productType or do we need to make this an argument instead of a hard coded value?

2. I added two helper methods for preparing the start and end periods. It's arguable if these belong to the pyfingrid.py or the script that calls pyfingrid.py but they are here for the time being. Rationale being that we do the timezone offset handling properly so that the users do not have to. This adds a dependency to pytz.

3. I'm also including an example implementation, datahub-consumption.py, which reads a previously captured session from a textfile, prints the consumption and logs what's going on.

4. Logfile, sessionfile and metering point number are defined in constant.py.

Cheers,
Markus