### PR TITLE
Issue 5: Example code for saving the session to file

### DIFF
--- a/datahub-authentication.py
+++ b/datahub-authentication.py
@@ -1,0 +1,18 @@
+import json
+import pyfingrid as fg
+
+# Open Chrome for strong authentication. Save cookies to a textfile for later usage.
+cookies = fg.get_cookies()
+f = open("session.txt", "w")
+f.write(json.dumps(cookies))
+f.close()
+
+# Print metering point information.
+session = fg.get_session(cookies)
+agreements = json.loads(fg.get_agreements(session))
+for agreement in agreements:
+    print("agreementIdentification: " + str(agreement['agreementIdentification']))
+    print("meteringPointEAN: " + str(agreement['accountingPoint']['meteringPointEAN']))
+
+# If you want to log out and end the session you just stored to the textfile, uncomment this.
+# print(fg.logout(session))

--- a/pyfingrid.py
+++ b/pyfingrid.py
@@ -5,7 +5,7 @@ import json,requests,time
 import urllib.parse
 
 def get_cookies():
-    """Get cookies from the Fingrid datahub API
+    """Opens Chrome with Selenium and returns cookies after a successful strong authentication.
 
     Raises:
         Exception: If login is not successful in 60 seconds
@@ -40,8 +40,8 @@ def get_session(c: dict):
     s.cookies.update(c)
     s.headers.update({'Authorization': 'Bearer ' + json.loads(urllib.parse.unquote(c['cap-user']))['token']})
     return s
-def get_metering_points(s : requests.Session):
-    """Get metering points from the Fingrid Datahub API
+def get_agreements(s : requests.Session):
+    """Get agreements from the Fingrid Datahub API
 
     Arguments:
         s {requests.Session} -- Session object


### PR DESCRIPTION
I wrote an example datahub-authentication that writes the cookies to session.txt and prints the metering point number in a human-readable fashion. While doing the latter, I noticed that the method name get_metering_points in pyfingrid.py was misleading, we're actually querying for the agreements and not metering points... 